### PR TITLE
Move index.html from sql-machine-learning.github.io to this repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<html>
+   <head>
+      <meta http-equiv="refresh" content="0; url=https://github.com/sql-machine-learning/pysqlflow" />
+      <link rel="canonical" href="https://github.com/sql-machine-learning/pysqlflow" />
+      <script>
+         window.location.replace("https:\/\/github.com\/sql-machine-learning\/pysqlflow");
+      </script>
+   </head>
+   <body>
+      <h1>Redirecting to <a href="https://github.com/sql-machine-learning/pysqlflow">https://github.com/sql-machine-learning/pysqlflow</a></h1>
+   </body>
+</html>


### PR DESCRIPTION
Following the idea https://github.com/sql-machine-learning/sql-machine-learning.github.io/pull/36/files#diff-04c6e90faac2675aa89e2176d2eec7d8R20, I am going to make this repo a git submodule `/pysqlflow` of the [Web site repo](https://github.com/sql-machine-learning/sql-machine-learning.github.io), so it will be easier for us to convert Markdown files in this repo into document pages of our Web site sqlflow.org.

However, there has been a directory named `/pysqlflow` in the [Web site repo](https://github.com/sql-machine-learning/sql-machine-learning.github.io), which contains a file `index.html`. So this PR is to move that file into this repo.