### PR TITLE
Remove unstable CI Python: 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ python:
 - 3.5
 - 3.6
 - 3.7
-- 3.8-dev
 
 install:
 - python setup.py -q install


### PR DESCRIPTION
Python 3.8-dev CI on https://github.com/sql-machine-learning/pysqlflow/pull/66 keeps failing after restarting several times. So I decided to remove check on this dev version.